### PR TITLE
Correcting the Id type for RequestServerInfo

### DIFF
--- a/schema/buttplug-schema.json
+++ b/schema/buttplug-schema.json
@@ -238,7 +238,7 @@
       "type": "object",
       "description": "Request server version, and relay client name.",
       "properties": {
-        "Id": {"$ref": "#/components/SystemId"},
+        "Id": {"$ref": "#/components/Id"},
         "ClientName": {
           "description": "Name of the client software.",
           "type": "string"


### PR DESCRIPTION
The RequestServerInfo message is sent from the client, so the Id should never be 0. Therefore type should be "#/components/Id" rather than "#/components/SystemId"