### PR TITLE
Allowing maxPingTime to be set to 0

### DIFF
--- a/schema/buttplug-schema.json
+++ b/schema/buttplug-schema.json
@@ -290,7 +290,7 @@
         "MaxPingTime": {
           "description": "Maximum time (in milliseconds) the server will wait between ping messages from client before shutting down.",
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
         }
       },
       "minProperties": 7,


### PR DESCRIPTION
It's useful to be able to disable the ping for debugging,
but the code currently rejects the ServerInfo message if
the maxPingTime is set to 0.

Fixes #31 