### PR TITLE
fix: Add DeviceRemoved to valid Message types array

### DIFF
--- a/schema/buttplug-schema.json
+++ b/schema/buttplug-schema.json
@@ -482,6 +482,7 @@
       "Test": {"$ref": "#/messages/Test"},
       "DeviceList": {"$ref": "#/messages/DeviceList"},
       "DeviceAdded": {"$ref": "#/messages/DeviceAdded"},
+      "DeviceRemoved": {"$ref": "#/messages/DeviceRemoved"},
       "RequestDeviceList": {"$ref": "#/messages/RequestDeviceList"},
       "StopDeviceCmd": {"$ref": "#/messages/StopDeviceCmd"},
       "StopAllDevices": {"$ref": "#/messages/StopAllDevices"},


### PR DESCRIPTION
We had a type definition for DeviceRemoved, but forgot to add it to
the overall message types array. This was never checked on the C# side
because we haven't tried to deal with that from a client there yet, so
we just caught it on the javascript side while implementing the schema
checker there.

Fixes #34