### PR TITLE
Spec rewording

### DIFF
--- a/protocol-spec/README.md
+++ b/protocol-spec/README.md
@@ -1,49 +1,49 @@
-# The Buttplug Sex Toy Control Standard
+# The Buttplug Computer Controlled Sex Device Control Standard
 
 * **Version:** 1
 * **Documentation Repo**: [https://github.com/metafetish/buttplug](https://github.com/metafetish/buttplug)
 
-Buttplug is a quasi-standard set of technologies and protocols to allow developers to write software that controls an array of sex toys in a semi-future-proof way.
+Buttplug is a quasi-standard set of technologies and protocols to allow developers to write software that controls an array of devices (sex toys, estim hardware, etc...) in a semi-future-proof way.
 
-## The Need for a Sex Toy Control Standard
+## The Need for a Computer Controlled Sex Device Control Standard
 
-If a user wants to access a computer controlled sex toy in a way not supported by the original manufacturer, the requirement list to is not trivial. There are some major hurdles between obtaining a sex toy and having DIY control of it:
+If a user wants to access a computer controlled sex device in a way not supported by the original manufacturer, the requirement list to is not trivial. There are some major hurdles between obtaining a device and having DIY control of it:
 
-* Experience in the operating system the user will want to access the sex toy from, including capabilities and programming interfaces to work with the connection medium \(serial/usb/bluetooth/etc\)
+* Experience in the operating system the user will want to access the device from, including capabilities and programming interfaces to work with the connection medium \(serial/usb/bluetooth/etc\)
 * Experience using a programming language that allows the user access to hardware via the operating system.
-* Knowledge of the communications protocol the sex toy uses. This is rarely, if ever, publicly documented information.
+* Knowledge of the communications protocol the device uses. This is rarely, if ever, publicly documented information.
 
-The Buttplug Sex Toy Control Standard seeks to lower these bars as much as possible.
+The Buttplug Sex Device Control Standard seeks to lower these bars as much as possible.
 
 * By proposing a standard that can be implemented in a cross-platform way, software based on the Buttplug Standard can reduce the amount of knowledge required to access hardware from a certain operating system or platform. Using technologies like Cordova or Xamarin to build software that implements Buttplug means that access could happen via desktop or mobile platforms.
-* By standardizing the methods that can be used to talk to these toys, implementations of the standard can happen in multiple languages and still interact with each other. This opens development opportunities to multiple communities and ecosystems.
-* Assuming some sort of widespread adoption happens, this could drive the commercial market to build toys with the Buttplug Standard in mind, or even to use it directly. Until that point, the portion of the community familiar with reverse engineering can help open sex toy access to those who are interested in controlling the toys.
+* By standardizing the methods that can be used to talk to these devices, implementations of the standard can happen in multiple languages and still interact with each other. This opens development opportunities to multiple communities and ecosystems.
+* Assuming some sort of widespread adoption happens, this could drive the commercial market to build devices with the Buttplug Standard in mind, or even to use it directly. Until that point, the portion of the community familiar with reverse engineering can help open device access to those who are interested in controlling the devices.
 
 ## Generalized Control
 
-One of the windmills Buttplug tilts at is the idea of "generalized control". Simply put, is it viable to drive completely different sex toys from the same control signal? In some cases, this is simple. In others, it may be impossible.
+One of the windmills Buttplug tilts at is the idea of "generalized control". Simply put, is it viable to drive completely different devices from the same control signal? In some cases, this is simple. In others, it may be impossible.
 
-Starting with the simple case, let's say a user has two sex toys, called Toy A and Toy B:
+Starting with the simple case, let's say a user has two devices, called Device A and Device B:
 
-* Each toy is made by a different manufacturer.
-* One toy uses Bluetooth to talk to the computer, the other uses USB.
-* Both of these toys have vibration functionality.
+* Each device is made by a different manufacturer.
+* One device uses Bluetooth to talk to the computer, the other uses USB.
+* Both of these devices have vibration functionality.
 
-The user has a particular function they would like to implement in a software application, which would utilize the vibration function of both toys.
+The user has a particular function they would like to implement in a software application, which would utilize the vibration function of both devices.
 
-Without Buttplug, this would require knowing how to talk to both USB and Bluetooth, and also knowing how each of these toys communicates with the computer in order to control vibration levels. They would then have to add both of these to their application.
+Without Buttplug, this would require knowing how to talk to both USB and Bluetooth, and also knowing how each of these devices communicates with the computer in order to control vibration levels. They would then have to add both of these to their application.
 
-With Buttplug, Server implementations are expected to take care of the different manufacturer and hardware communication requirements. However, if there were only ways to communicate with specific hardware, the application they were making would have to provide separate logic paths to cover either toy instance.
+With Buttplug, Server implementations are expected to take care of the different manufacturer and hardware communication requirements. However, if there were only ways to communicate with specific hardware, the application they were making would have to provide separate logic paths to cover either device instance.
 
-This is where the idea of "generalized haptics" comes in. Instead of either a "Toy A" or "Toy B" command to the server, the user can just send a "Vibrate" command to the server, along with the identifier for which toy they wanted to use. Not only that, their software would work with any toy \(including toys they do not own/have tested with\) that could translate the "Vibrate" command.
+This is where the idea of "generalized haptics" comes in. Instead of either a "Device A" or "Device B" command to the server, the user can just send a "VibrateCmd" command to the server, along with the identifier for which device they wanted to use. Not only that, their software would work with any device \(including devices they do not own/have tested with\) that could translate the "VibrateCmd" command.
 
 Now, the not so simple case.
 
-Let's add Toy C, an electrostimulation unit. To use Toy C with the same application as Toy A and Toy B, the Vibrate command has to be translated into some facsimile that is valid for estim. While this is most likely not tractable for a global solution, the goal of Buttplug is to make explorations of ideas like this accessible and easy to play with.
+Let's add Device C, an electrostimulation unit. To use Device C with the same application as Device A and Device B, the Vibrate command has to be translated into some facsimile that is valid for estim. While this is most likely not tractable for a global solution, the goal of Buttplug is to make explorations of ideas like this accessible and easy to play with.
 
 ## Comparisons to Existing Software
 
-It's somewhat difficult to point to a real world counterpart for the Buttplug Standard. While companies like [Frixion](http://twitter.com/frixionme) and [FeelMe](http://feelme.com) have created systems for controlling different sex toys, neither of those is open source, so it's hard to point at them as examples.
+It's somewhat difficult to point to a real world counterpart for the Buttplug Standard. While companies like [Frixion](http://twitter.com/frixionme) and [FeelMe](http://feelme.com) have created systems for controlling different devices, neither of those is open source, so it's hard to point at them as examples.
 
 The closest existing projects are those which reinterpret or generalize control schemes. Projects like:
 
@@ -56,14 +56,15 @@ All of these programs take input from various devices and translate them as some
 
 ## Why is it called Buttplug?
 
-It probably seems silly to call a sex toy control standard "Buttplug".
+It probably seems silly to call a generic device control standard "Buttplug".
 
 That's because it is.
 
-I could probably call this project something neutral like STCS, but I've been referring to computer controlled sex toys as "Internet Buttplugs" for years, and that's what influenced the name of this project. It's hard to pick terms for these products.
+I could probably call this project something neutral like Sex Device Control Standard (SDCS?), but I've been referring to computer controlled sex devices as "Internet Buttplugs" for years, and that's what influenced the name of this project. It's hard to pick terms for these products.
 
 * "Sex toy" is weighed down by the word "toy". This is part of the reason the academic and tech community is flocking toward "sex robot" even when discussing technology that would've been called a sex toy a decade ago.
 * "Sex robot" has way too many connotations, be it Cherry 2000 or robotics academics writing media-friendly PhD theses.
+* "Sex device" is used in this document, but feels awkward for reasons I'm still figuring out.
 * "Adult novelty" just sounds stale and corporate. You buy adult novelties in bulk from warehouses. You go to adult novelty conventions.
 * "Marital aide" No.
 

--- a/protocol-spec/SUMMARY.md
+++ b/protocol-spec/SUMMARY.md
@@ -1,5 +1,5 @@
-* [The Buttplug Sex Toy Control Standard](README.md#the-buttplug-sex-toy-control-standard)
-  * [The Need for a Sex Toy Control Standard](README.md#the-need-for-a-sex-toy-control-standard)
+* [The Buttplug Computer Controlled Sex Device Control Standard](README.md#the-buttplug-computer-controlled-sex-device-control-standard)
+  * [The Need for a Sex Device Control Standard](README.md#the-need-for-a-sex-device-control-standard)
   * [Generalized Control](README.md#generalized-control)
   * [Comparisons to Existing Software](README.md#comparisons-to-existing-software)
   * [Why is it called Buttplug?](README.md#why-is-it-called-buttplug)

--- a/protocol-spec/generic.md
+++ b/protocol-spec/generic.md
@@ -206,14 +206,13 @@ In order to abstract the dynamic ranges (both speed and movement) of different t
 * _DeviceIndex_ \(unsigned int\): Index of device
 * _Vectors_ \(array\): Linear actuator speeds and positions
   * _Index_ \(unsigned int\): Index of linear actuator
-  * _Time_ \(unsigned int\): Movement time in milliseconds
+  * _Duration_ \(unsigned int\): Movement time in milliseconds
   * _Position_ \(double\): Target position with a range of \[0.0-1.0\]
 
 **Expected Response:**
 
 * Ok message with matching Id on successful request.
 * Error message on value or message error.
-
 
 **Serialization Example:**
 
@@ -226,12 +225,12 @@ In order to abstract the dynamic ranges (both speed and movement) of different t
       "Vectors": [
         {
           "Index": 0,
-          "Speed": 0.5,
+          "Duration": 500,
           "Position": 0.3
         },
         {
           "Index": 1,
-          "Speed": 1,
+          "Duration": 1000,
           "Posiion": 0.8
         }
       ]

--- a/protocol-spec/generic.md
+++ b/protocol-spec/generic.md
@@ -109,7 +109,7 @@
 
 **Deprecated:** This message has been superseded by [VibrateCmd](generic.md#vibratecmd)
 
-**Description:** Causes a toy that supports vibration to run all vibration motors at a certain speed. In order to abstract the dynamic range of different toys, the value sent is a float with a range of \[0.0-1.0\]
+**Description:** Causes a device that supports vibration to run all vibration motors at a certain speed.
 
 **Introduced In Version:** 0
 
@@ -119,7 +119,7 @@
 
 * _Id_ \(unsigned int\): Message Id
 * _DeviceIndex_ \(unsigned int\): Index of device
-* _Speed_ \(float\): Vibration speed
+* _Speed_ \(double\): Vibration speed with a range of \[0.0-1.0\]
 
 **Expected Response:**
 
@@ -146,9 +146,7 @@
 
 ## VibrateCmd
 
-**Description:** Causes a toy that supports vibration to run specific vibration motors at a certain speeds. Devices with multiple vibrator features may take multiple values. The [FeatureCount](enumeration.md#messageattributes) attribute for the message in the [DeviceList](enumeration.md#devicelist)/[DeviceAdded](enumeration.md#deviceadded) message will contain that information.
-
-Since devices may differ in terms of range of vibration strengths, the values are sent as a dictionary of vibration motor indexes against floats with a range of \[0.0-1.0\] wihich will be scaled appropriately for the device.
+**Description:** Causes a device that supports vibration to run specific vibration motors at a certain speeds. Devices with multiple vibrator features may take multiple values. The [FeatureCount](enumeration.md#messageattributes) attribute for the message in the [DeviceList](enumeration.md#devicelist)/[DeviceAdded](enumeration.md#deviceadded) message will contain that information.
 
 **Introduced In Version:** 1
 
@@ -192,9 +190,7 @@ Since devices may differ in terms of range of vibration strengths, the values ar
 
 ## LinearCmd
 
-**Description:** Causes a toy that supports linear movement to move to a position over a certain amount of time. Devices with multiple linear actuator features may take multiple values. The [FeatureCount](enumeration.md#messageattributes) attribute for the message in the [DeviceList](enumeration.md#devicelist)/[DeviceAdded](enumeration.md#deviceadded) message will contain that information.
-
-In order to abstract the dynamic ranges (both speed and movement) of different toys, the values are sent as a dictionary of linear actuator indexes against objects encapsulating floats with a range of \[0.0-1.0\] for speed and position.
+**Description:** Causes a device that supports linear movement to move to a position over a certain amount of time. Devices with multiple linear actuator features may take multiple values. The [FeatureCount](enumeration.md#messageattributes) attribute for the message in the [DeviceList](enumeration.md#devicelist)/[DeviceAdded](enumeration.md#deviceadded) message will contain that information.
 
 **Introduced In Version:** 1
 
@@ -241,9 +237,7 @@ In order to abstract the dynamic ranges (both speed and movement) of different t
 
 ## RotateCmd
 
-**Description:** Causes a toy that supports rotation to rotate at a certain speeds in specified directions. Devices with multiple rotating features may have multiple values. The [FeatureCount](enumeration.md#messageattributes) attribute for the message in the [DeviceList](enumeration.md#devicelist)/[DeviceAdded](enumeration.md#deviceadded) message will have this information.
-
-In order to abstract the dynamic range of different toys, the values are sent as a dictionary of rotation motor indexes against objects encapsulating the speed as a float with a range of \[0.0-1.0\] and the direction as a boolean (true being clockwise). **Note:** clockwise may be subjective.
+**Description:** Causes a device that supports rotation to rotate at a certain speeds in specified directions. Devices with multiple rotating features may have multiple values. The [FeatureCount](enumeration.md#messageattributes) attribute for the message in the [DeviceList](enumeration.md#devicelist)/[DeviceAdded](enumeration.md#deviceadded) message will have this information.
 
 **Introduced In Version:** 1
 

--- a/protocol-spec/messages.md
+++ b/protocol-spec/messages.md
@@ -62,14 +62,20 @@ Similarly, some message values will have certain bounds and limitations. These a
 
 ## Adding New Messages
 
-The message list as described here is not set in stone. New messages will be added as new devices are released, or as new generic messages are deemed necessary. The only rule is that once a message is added to this document, it should never be removed; however, newer versions of the message may suceed it. This will allow parsing andschema checking to be as strict as possible. If edits to a message need to be made, a new message type will most likely be added.
+The message list as described here is not set in stone. New messages will be added as new devices are released, or as new generic messages are deemed necessary. The only rule is that once a message is added to this document, it should never be removed; however, newer versions of the message may suceed it. This will allow parsing and schema checking to be as strict as possible. If edits to a message need to be made, a new message type will most likely be added.
 
 Requests for new messages can be submitted to [the Buttplug Standard Github Issue Tracker](https://github.com/metafetish/buttplug/issues).
 
 ## Message Versioning
 
-In order to cope with changes to the schema across servers and clients that may not both support the same schema versions, each message type defined in this document has a message version number. These are based on the schema version they were introduced in, represented as an unsigned integer. As of version 1, this document and the schema are synchronized by using the message version over any other form of release number. Version 0 was represented as release 0.1.0.
+Each protocol message type has a version number, to cope with protocol version differences between servers and clients. This version is based on the protocol version the message was introduced in, and is represented as an unsigned integer. 
 
-The message versions are not contained in the messages themselves, instead the client sends the overall schema message version as part of the RequestServerInfo message and the server includes its schema message version in the ServerInfo response. Note that the original version of RequestServerInfo does not have a parameter for this, so the servers that implement version 0 will reject clients capable of using the version 1 schema. This is not seen as an issue, as the server is likely to be the first component in the Buttplug archtecture to be updated, and is the component most likely to be under the end-user's control to update.
+To establish protocol versions between clients and servers, the client sends the overall protocol message version as part of the [RequestServerInfo](identification.md#requestserverinfo) message (as the MessageVersion field), and the server includes its protocol version in the [RequestServerInfo](identification.md#serverinfo) response (as the MessageVersion field). 
 
-In the case that the server supports a newer schema than the client, any messages that the server attempts to send will be checked against the message version and either downgraded to a previous version where possible, or simply dropped.
+If a server supports a newer protocol version than a client, any messages that the server attempts to send will be checked against the client protocol version, and either downgraded to a previous version where possible, or simply dropped. Server support for downgrading a message is optional, and it is not expected that all servers will support downgrading through all versions of the protocol.
+
+If a client supports a newer protocol version than a server, this is considered an invalid connection situation, and a disconnect should insue. This rule is based on the assumption that the user can most likely update the server version to something newer. The client may not be easily upgraded for many reasons, such as being a proprietary application or source code not being easily accessible, being to complex to work on and upgrade, etc...
+
+**Note:** Spec Version 0 was listed as Spec Version 0.1.0 initially.
+
+**Note**: Version 0 of the RequestServerInfo message does not have a parameter for protocol version. Servers that implement version 0 will reject clients capable of using the version 1 schema. This is not seen as an issue, as the server is likely to be the first component in the Buttplug archtecture to be updated, and is most likely to be under the end-user's control to update.

--- a/protocol-spec/messages.md
+++ b/protocol-spec/messages.md
@@ -25,7 +25,7 @@ There are two types of message flows.
 
 The Buttplug Message System, as described here, was not designed to scale to large multiuser systems \(like cam services\). It was built with either a single user, peer-to-peer, or small group setting in mind.
 
-As the message flow section states, this system resembles a sort of half-assed-TCP mechanism. Using this system to drive large scale toy control streaming services may require changes to this system.
+As the message flow section states, this system resembles a sort of half-assed-TCP mechanism. Using this system to drive large scale device control streaming services may require changes to this system.
 
 Reducing and rearchitecting this system for scaling is an exercise left to the developer. Either to implement, or to contract the Buttplug designers to build it for them.
 

--- a/protocol-spec/specific.md
+++ b/protocol-spec/specific.md
@@ -2,7 +2,7 @@
 
 ## KiirooCmd
 
-**Description:** Causes a toy that supports Kiiroo style commands to run whatever event may be related. More information on Kiiroo commands can be found in STPIHKAL.
+**Description:** Causes a device that supports Kiiroo style commands to run whatever event may be related. More information on Kiiroo commands can be found in STPIHKAL.
 
 **Introduced In Version:** 0
 
@@ -39,7 +39,7 @@
 
 ## FleshlightLaunchFW12Cmd
 
-**Description:** Causes a toy that supports Fleshlight Launch \(Firmware Version 1.2\) style commands to run whatever event may be related. More information on Fleshlight Launch commands can be found in STPIHKAL.
+**Description:** Causes a device that supports Fleshlight Launch \(Firmware Version 1.2\) style commands to run whatever event may be related. More information on Fleshlight Launch commands can be found in STPIHKAL.
 
 **Introduced In Version:** 0
 
@@ -78,7 +78,7 @@
 
 ## LovenseCmd
 
-**Description:** Causes a toy that supports Lovense style commands to run whatever event may be related. More information on Lovense commands can be found in STPIHKAL.
+**Description:** Causes a device that supports Lovense style commands to run whatever event may be related. More information on Lovense commands can be found in STPIHKAL.
 
 **Introduced In Version:** 0
 
@@ -88,7 +88,7 @@
 
 * _Id_ \(unsigned int\): Message Id
 * _DeviceIndex_ \(unsigned int\): Index of device
-* _Command_ \(string\): String command for Lovense toys. Must be a valid Lovense command accessible on most of their toys. See STPIHKAL for more info. Implementations should check this for validity.
+* _Command_ \(string\): String command for Lovense devices. Must be a valid Lovense command accessible on most of their devices. See STPIHKAL for more info. Implementations should check this for validity.
 
 **Expected Response:**
 
@@ -115,7 +115,7 @@
 
 ## VorzeA10CycloneCmd
 
-**Description:** Causes a toy that supports Vorze A10 Cyclone style commands to run whatever event may be related. More information on Vorze commands can be found in STPIHKAL.
+**Description:** Causes a device that supports Vorze A10 Cyclone style commands to run whatever event may be related. More information on Vorze commands can be found in STPIHKAL.
 
 **Introduced In Version:** 0
 


### PR DESCRIPTION
- Fix LinearCmd message fields and example
- Reduce usage of "toy", use "device" wherever possible
- Simplify message version section and add more client/server version different rules.

Not sure if we should encode the "client version > server version" rule in the spec? I mean I suppose someone could figure out a way to build both directions, and we could leave it as a reference implementation rule for now?