### PR TITLE
minor json fixes

### DIFF
--- a/protocol-spec/generic.md
+++ b/protocol-spec/generic.md
@@ -180,7 +180,7 @@
         },
         {
           "Index": 1,
-          "Speed": 1
+          "Speed": 1.0
         }
       ]
     }
@@ -227,7 +227,7 @@
         {
           "Index": 1,
           "Duration": 1000,
-          "Posiion": 0.8
+          "Position": 0.8
         }
       ]
     }
@@ -262,7 +262,7 @@
 ```json
 [
   {
-    "RotationCmd": {
+    "RotateCmd": {
       "Id": 1,
       "DeviceIndex": 0,
       "Rotations": [
@@ -273,7 +273,7 @@
         },
         {
           "Index": 1,
-          "Speed": 1,
+          "Speed": 1.0,
           "Clockwise": false
         }
       ]

--- a/protocol-spec/identification.md
+++ b/protocol-spec/identification.md
@@ -31,7 +31,7 @@
     "RequestServerInfo": {
       "Id": 1,
       "ClientName": "Test Client",
-      "MessageVersion": 1,
+      "MessageVersion": 1
     }
   }
 ]
@@ -100,10 +100,10 @@ None. Server-To-Client message only.
     "ServerInfo": {
       "Id": 1,
       "ServerName": "Test Server",
-      "MessageVersion": 1,
       "MajorVersion": 1,
       "MinorVersion": 0,
       "BuildVersion": 0,
+      "MessageVersion": 1,
       "MaxPingTime": 100
     }
   }

--- a/protocol-spec/specific.md
+++ b/protocol-spec/specific.md
@@ -31,7 +31,7 @@
     "KiirooCmd": {
       "Id": 1,
       "DeviceIndex": 0,
-      "Command": 4
+      "Command": "4"
     }
   }
 ]


### PR DESCRIPTION
fixes for a bad name, an extra comma, a few typos, and a few incorrect types in the json examples